### PR TITLE
[Fix] Remove cache behavior on creator API

### DIFF
--- a/src/lib/nextApi.ts
+++ b/src/lib/nextApi.ts
@@ -4,9 +4,9 @@ import { HttpException } from '@/lib/HttpExceptions';
 
 const isDevMode = process.env.NODE_ENV === 'development';
 
-async function nextFetch<T>(url: string, option?: RequestInit): Promise<T> {
+async function nextFetch<T>(url: string, option?: RequestInit, disabledCache?: boolean): Promise<T> {
   const fetchOption = { ...option };
-  if (isDevMode) {
+  if (isDevMode || disabledCache) {
     fetchOption.cache = 'no-store';
   } else {
     fetchOption.next = { revalidate: 60 };
@@ -63,6 +63,6 @@ export async function getCreatorById(id: string, token?: string) {
       Authorization: `Bearer ${token}`,
     };
   }
-  const res = await nextFetch<Creator>(`/creator/${id}`, options);
+  const res = await nextFetch<Creator>(`/creator/${id}`, options, true);
   return res;
 }


### PR DESCRIPTION
### Fix
目前因為創作者資訊頁獲取 API 有 60 秒 cache，會造成追蹤後就算重整也不會馬上更新追蹤數字，暫時先把 cache 拿掉解決此問題

Note: 數字要拆出來變成 client component 做樂觀更新目前想不到比較好的做法