### PR TITLE
Refactor/edit publish article

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -45,6 +45,7 @@ export default function Login() {
     const redirectUrl = localStorage.getItem(LOCAL_STORAGE_KEY.redirectUrl);
     if (redirectUrl) {
       router.replace(redirectUrl);
+      router.refresh();
     } else {
       router.replace('/manage/user');
     }

--- a/src/app/(global)/(dashboard)/article/edit/[id]/page.tsx
+++ b/src/app/(global)/(dashboard)/article/edit/[id]/page.tsx
@@ -3,65 +3,72 @@
 import EditorWrapper from '@/components/editor/EditorWrapper';
 import { useQuery } from '@tanstack/react-query';
 import { getArticleById } from '@/lib/nextApi';
-import { useRouter } from 'next/navigation';
+import { notFound, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useUserStore } from '@/providers/userProvider';
-import { verifyAuthor } from '@/lib/utils';
 import { Lock, PenLine } from 'lucide-react';
 import LoadingEditorSkeleton from '@/components/LoadingEditorSkeleton';
-import { type Article } from '@/types/article';
 import jsCookie from 'js-cookie';
 import { JOURNEY_BITES_COOKIE } from '@/constants';
 
 type Props = {
   params: { id: string }
-  searchParams: { [key: string]: string | string[] | undefined }
 }
 
 const EditArticle: React.FC<Props> = ({ params }) => {
-  const [editContent, setEditContent] = useState<Article | undefined>(undefined);
   const [isAuthor, setIsAuthor] = useState(false);
-  const [isVerifying, setIsVerifying] = useState(true);
   const router = useRouter();
   const { id } = params;
   const { auth } = useUserStore((state) => state);
 
   const token = jsCookie.get(JOURNEY_BITES_COOKIE);
-  const { isPending, isError, data, error } = useQuery({
+  const { isLoading, data: editingContent, isError } = useQuery({
     queryKey: ['getArticleById', id],
     queryFn: () => getArticleById(id, token),
   });
 
   useEffect(() => {
-    if (data) {
-      const { creator } = data;
-      setEditContent(data);
+    if (editingContent) {
+      const { creator } = editingContent;
 
       if (auth && auth.id) {
-        verifyAuthor(creator?.id, auth.id, router, () => setIsAuthor(true));
-        setIsVerifying(false);
-      }
-
-      if (isError) {
-        console.log(error);
+        if(creator.id === auth.id) {
+          setIsAuthor(true);
+        } else {
+          setIsAuthor(false);
+        }
       }
     }
-  }, [data, auth, router, isError, error]);
+  }, [editingContent, auth, router]);
+
+  if (isLoading) {
+    return (
+      <main className='min-h-screen w-full pb-10'>
+        <LoadingEditorSkeleton />
+      </main>
+    );
+  }
+
+  if (isError) {
+    return notFound();
+  }
+
+  if (!isAuthor) {
+    return (
+      <main className='min-h-screen w-full pb-10'>
+        <div className='mt-10 flex justify-center text-center text-red-500'>
+          <Lock /><p className='ml-2'>您沒有編輯此文章的權限</p>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className='min-h-screen w-full pb-10'>
-    <div className='mt-10 flex items-center justify-center gap-2 text-center text-2xl font-semibold text-grey-300'>
-      <PenLine />編輯文章
-    </div>
-    {isPending || isVerifying ? (
-      <LoadingEditorSkeleton />
-      ) : isAuthor ? (
-        <>
-        <EditorWrapper isEditing={true} editContent={editContent} />
-        </>
-      ) : (
-        <div className='mt-10 flex justify-center text-center text-red-500'><Lock /><p className='ml-2'>您沒有編輯此文章的權限</p></div>
-      )}
+      <div className='mt-10 flex items-center justify-center gap-2 text-center text-2xl font-semibold text-grey-300'>
+        <PenLine />編輯文章
+      </div>
+      <EditorWrapper isEditing={true} editContent={editingContent} />
     </main>
   );
 };

--- a/src/app/(global)/(dashboard)/article/edit/[id]/page.tsx
+++ b/src/app/(global)/(dashboard)/article/edit/[id]/page.tsx
@@ -9,7 +9,7 @@ import { useUserStore } from '@/providers/userProvider';
 import { Lock, PenLine } from 'lucide-react';
 import LoadingEditorSkeleton from '@/components/LoadingEditorSkeleton';
 import jsCookie from 'js-cookie';
-import { JOURNEY_BITES_COOKIE } from '@/constants';
+import { JOURNEY_BITES_COOKIE, QUERY_KEY } from '@/constants';
 
 type Props = {
   params: { id: string }
@@ -23,7 +23,7 @@ const EditArticle: React.FC<Props> = ({ params }) => {
 
   const token = jsCookie.get(JOURNEY_BITES_COOKIE);
   const { isLoading, data: editingContent, isError } = useQuery({
-    queryKey: ['getArticleById', id],
+    queryKey: [QUERY_KEY.article, id],
     queryFn: () => getArticleById(id, token),
   });
 

--- a/src/app/(global)/(dashboard)/article/publish/[id]/page.tsx
+++ b/src/app/(global)/(dashboard)/article/publish/[id]/page.tsx
@@ -25,7 +25,7 @@ import StatusCode from '@/types/StatusCode';
 import { CreateArticleRequest } from '@/types/article';
 import { useUserStore } from '@/providers/userProvider';
 import LoadingEditorSkeleton from '@/components/LoadingEditorSkeleton';
-import { JOURNEY_BITES_COOKIE } from '@/constants';
+import { JOURNEY_BITES_COOKIE, QUERY_KEY } from '@/constants';
 import { Lock } from 'lucide-react';
 
 const isNeedPayOptions: { id: string; name: string; }[]= [
@@ -57,7 +57,7 @@ export default function PublishArticle({ params }: { params: { id: string } }) {
   });
 
   const { isPending, data, isError } = useQuery({
-    queryKey: ['getArticleById', id],
+    queryKey: [QUERY_KEY.article, id],
     queryFn: () => getArticleById(id, token),
   });
 

--- a/src/app/(global)/(dashboard)/article/publish/page.tsx
+++ b/src/app/(global)/(dashboard)/article/publish/page.tsx
@@ -122,11 +122,6 @@ export default function PublishArticle() {
   });
   const { control, handleSubmit, formState: { isValid } } = form;
 
-  function setValue(arg0: string, arg1: [Tag, ...Tag[]]) {
-    console.log(arg0, arg1);
-    console.log(arg1);
-  }
-
   return (
     <main className='mx-auto mb-10 grid size-full max-w-[800px] place-items-center'>
       <div className='mb-10 pt-10 text-center text-3xl text-primary-300'>
@@ -139,7 +134,7 @@ export default function PublishArticle() {
               className='w-full'
               control={control}
               name='title'
-              label='標題'
+              label='*標題'
               placeholder='文章標題'
             />
             <TextAreaField
@@ -161,7 +156,7 @@ export default function PublishArticle() {
               className='w-full'
               control={control}
               name='category'
-              label='文章分類'
+              label='*文章分類'
               placeholder='設定文章分類'
               options={categoryOptions}
             />
@@ -169,7 +164,7 @@ export default function PublishArticle() {
               className='w-full'
               control={control}
               name='isNeedPay'
-              label='內容收費'
+              label='*內容收費'
               placeholder='設定文章是否收費'
               options={isNeedPayOptions}
             />
@@ -183,7 +178,6 @@ export default function PublishArticle() {
                     tags={tags}
                     setTags={(newTags) => {
                       setTags(newTags);
-                      setValue('tags', newTags as [Tag, ...Tag[]]);
                       field.onChange(newTags);
                     }}
                     placeholder='為文章加上標籤'

--- a/src/app/(global)/(dashboard)/article/publish/page.tsx
+++ b/src/app/(global)/(dashboard)/article/publish/page.tsx
@@ -34,6 +34,8 @@ export default function PublishArticle() {
   const [categoryOptions, setCategoryOptions] = useState<{ id: string; name: string; }[]>([]);
   const router = useRouter();
 
+  const { mutate: createArticleMutate, isPending: isUpdateCreateArticle } = useMutation({ mutationFn: createArticle });
+
   const categoryValidation = z.string().refine(value => categoryOptions.some(option => option.name === value), {
     message: '選項為必填',
   });
@@ -50,8 +52,6 @@ export default function PublishArticle() {
     isNeedPay: isNeedPayValidation,
     tags: z.array(z.object({ id: z.string(), text: z.string() })).optional(),
   });
-
-  const { mutate: createArticleMutate, isPending: isUpdateCreateArticle } = useMutation({ mutationFn: createArticle });
 
   useEffect(() => {
     if(!editorProps) {
@@ -134,8 +134,9 @@ export default function PublishArticle() {
               className='w-full'
               control={control}
               name='title'
-              label='*標題'
+              label='標題'
               placeholder='文章標題'
+              isRequired={true}
             />
             <TextAreaField
               className='w-full resize-none'
@@ -156,17 +157,19 @@ export default function PublishArticle() {
               className='w-full'
               control={control}
               name='category'
-              label='*文章分類'
+              label='文章分類'
               placeholder='設定文章分類'
               options={categoryOptions}
+              isRequired={true}
             />
             <SelectField
               className='w-full'
               control={control}
               name='isNeedPay'
-              label='*內容收費'
+              label='內容收費'
               placeholder='設定文章是否收費'
               options={isNeedPayOptions}
+              isRequired={true}
             />
             <Controller
               name='tags'

--- a/src/app/(global)/(dashboard)/article/publish/page.tsx
+++ b/src/app/(global)/(dashboard)/article/publish/page.tsx
@@ -20,7 +20,7 @@ const PublishArticle = () => {
   const router = useRouter();
   const [activeTagIndex, setActiveTagIndex] = useState < number | null > (null);
 
-  const { form, onSubmit, categoryOptions, tags, setTags, isUpdateArticle } = usePublishForm({
+  const { form, onSubmit, categoryOptions, tags, setTags: setFormTags, isUpdateArticle } = usePublishForm({
     title: '',
     abstract: '',
     thumbnailUrl: '',
@@ -94,7 +94,7 @@ const PublishArticle = () => {
                     {...field}
                     tags={tags}
                     setTags={(newTags) => {
-                      setTags(newTags);
+                      setFormTags(newTags);
                       field.onChange(newTags);
                     }}
                     placeholder='為文章加上標籤'

--- a/src/components/Header/UserMenuList.tsx
+++ b/src/components/Header/UserMenuList.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { LogOutIcon } from 'lucide-react';
 import { useUserStore } from '@/providers/userProvider';
 import { DropdownMenuLinkItem } from '@/components/custom/DropdownMenu';
@@ -33,13 +34,16 @@ const MENU_LINKS: { title: string, href: string }[] = [
 
 export default function UserMenuList({ isDropdownMenu }: { isDropdownMenu?: boolean }) {
   const { auth, removeAuth } = useUserStore((state) => state);
+  const router = useRouter();
 
   async function handleLogout() {
     try {
       await logout();
       removeAuth();
+      router.refresh();
     } catch (error) {
       removeAuth();
+      router.refresh();
     }
   }
 

--- a/src/components/article/CommentSection.tsx
+++ b/src/components/article/CommentSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
 import { FieldValues, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -62,8 +62,15 @@ export default function CommentSection({ articleId }: { articleId: string }) {
       onSuccess: () => {
         reset();
         setShowAll(true);
+
         if (comments) setInitialVisibleCount(prev => prev + comments.length);
         queryClient.invalidateQueries({ queryKey: [QUERY_KEY.comments] });
+
+        setTimeout(() => {
+          if (latestCommentRef.current) {
+            latestCommentRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }
+        }, 500);
       },
       onError: () => {
         toast({ title: '新增留言失敗', description: '請聯繫客服，或稍後再試', variant: 'error' });
@@ -72,12 +79,6 @@ export default function CommentSection({ articleId }: { articleId: string }) {
   }
 
   const debounceSubmit = debounce(handleSubmit(onSubmit), 500);
-
-  useEffect(() => {
-    if (latestCommentRef.current) {
-      latestCommentRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
-  }, [comments]);
 
   if (!comments) return null;
 

--- a/src/components/custom/InputField.tsx
+++ b/src/components/custom/InputField.tsx
@@ -11,6 +11,7 @@ type InputFieldProps<T extends FieldValues> = {
   label?: string;
   inputType?: HTMLInputTypeAttribute;
   placeholder?: string;
+  isRequired?: boolean;
   formDescription?: string;
   startIcon?: LucideIcon;
   endIcon?: LucideIcon;
@@ -18,14 +19,19 @@ type InputFieldProps<T extends FieldValues> = {
   onBlur?: () => void;
 }
 
-export default function InputField<T extends FieldValues>({ className, control, name, label, inputType, placeholder, formDescription, startIcon, endIcon, iconAction, onBlur }: InputFieldProps<T>) {
+export default function InputField<T extends FieldValues>({ className, control, name, label, inputType, placeholder, isRequired, formDescription, startIcon, endIcon, iconAction, onBlur }: InputFieldProps<T>) {
   return (
     <FormField
       control={control}
       name={name}
       render={({ field }) => (
         <FormItem>
-          {label && <FormLabel>{label}</FormLabel>}
+          {label && (
+            <FormLabel>
+              {isRequired && <span style={{ color: 'red' }}> * </span>}
+              {label}
+            </FormLabel>
+          )}
           <FormControl>
             <Input
               className={className}

--- a/src/components/custom/InputField.tsx
+++ b/src/components/custom/InputField.tsx
@@ -28,7 +28,7 @@ export default function InputField<T extends FieldValues>({ className, control, 
         <FormItem>
           {label && (
             <FormLabel>
-              {isRequired && <span style={{ color: 'red' }}> * </span>}
+              {isRequired && <span className='text-danger'> * </span>}
               {label}
             </FormLabel>
           )}

--- a/src/components/custom/SelectField.tsx
+++ b/src/components/custom/SelectField.tsx
@@ -10,18 +10,24 @@ type SelectFieldProps<T extends FieldValues> = {
   name: Path<T>;
   label: string;
   placeholder?: string;
+  isRequired?: boolean;
   formDescription?: string;
   options: { id: string, name: string }[];
 };
 
-export default function SelectField<T extends FieldValues>({ className, control, name, label, placeholder, formDescription, options }: SelectFieldProps<T>) {
+export default function SelectField<T extends FieldValues>({ className, control, name, label, placeholder, isRequired, formDescription, options }: SelectFieldProps<T>) {
   return (
     <FormField
       control={control}
       name={name}
       render={({ field }) => (
       <FormItem className={className}>
-        <FormLabel>{label}</FormLabel>
+        {label && (
+          <FormLabel>
+            {isRequired && <span style={{ color: 'red' }}> * </span>}
+            {label}
+          </FormLabel>
+        )}
         <Select onValueChange={field.onChange} defaultValue={field.value}>
           <FormControl>
             <SelectTrigger>

--- a/src/components/custom/SelectField.tsx
+++ b/src/components/custom/SelectField.tsx
@@ -24,7 +24,7 @@ export default function SelectField<T extends FieldValues>({ className, control,
       <FormItem className={className}>
         {label && (
           <FormLabel>
-            {isRequired && <span style={{ color: 'red' }}> * </span>}
+            {isRequired && <span className='text-danger'> * </span>}
             {label}
           </FormLabel>
         )}

--- a/src/components/editor/EditorWrapper.tsx
+++ b/src/components/editor/EditorWrapper.tsx
@@ -46,8 +46,6 @@ const EditorWrapper: React.FC<EditorWrapperProps> = ({ isEditing, editContent })
       return router.push(`/article/publish/${options?.id}`);
     }
     router.push('/article/publish');
-    // setContent('');
-    // console.log(editorProps)
   };
 
   useEffect(() => {

--- a/src/components/editor/Tiptap.tsx
+++ b/src/components/editor/Tiptap.tsx
@@ -11,7 +11,7 @@ import CharacterCount from '@tiptap/extension-character-count';
 import { LIMIT as limit } from '@/constants/editorSettings';
 import Placeholder from '@tiptap/extension-placeholder';
 import GlobalDragHandle from 'tiptap-extension-global-drag-handle';
-import Document from '@tiptap/extension-document';
+// import Document from '@tiptap/extension-document';
 import { ResizableImage } from 'tiptap-extension-resizable-image';
 import '@/components/editor/style.css';
 import 'tiptap-extension-resizable-image/styles.css';
@@ -22,9 +22,9 @@ interface TiptapProps {
   content: string;
 }
 
-const forceTitleDocument = Document.extend({
-  content: 'paragraph block*',
-});
+// const forceTitleDocument = Document.extend({
+//   content: 'paragraph block*',
+// });
 
 const Tiptap = ({ onChange, content }: TiptapProps) => {
   const handleChange = useCallback((newContent: string) => {
@@ -35,10 +35,10 @@ const Tiptap = ({ onChange, content }: TiptapProps) => {
     content,
     editable: true,
     extensions: useMemo(() => [
-      forceTitleDocument,
+      // forceTitleDocument,
       ResizableImage,
       StarterKit.configure({
-        document: false,
+        // document: false,
         heading: {
           HTMLAttributes:
           {
@@ -98,14 +98,14 @@ const Tiptap = ({ onChange, content }: TiptapProps) => {
       Placeholder.configure({
         // considerAnyAsEmpty: true,
         // showOnlyCurrent: false,
-        // placeholder: '開始屬於你的精彩創作...',
-        placeholder: ({ node }) => {
-          if (node.type.name === 'heading') {
-            return '請輸入標題';
-          }
+        placeholder: '開始屬於你的精彩創作...',
+        // placeholder: ({ node }) => {
+        //   if (node.type.name === 'heading') {
+        //     return '請輸入標題';
+        //   }
 
-          return '開始屬於你的精彩創作...';
-        },
+        //   return '開始屬於你的精彩創作...';
+        // },
       }),
     ], []),
     editorProps: {

--- a/src/components/editor/Tiptap.tsx
+++ b/src/components/editor/Tiptap.tsx
@@ -89,6 +89,7 @@ const Tiptap = ({ onChange, content }: TiptapProps) => {
         validate: (href: string) => /^https?:\/\//.test(href),
         HTMLAttributes: {
           class: 'text-primary',
+          target: '_blank',
         },
       }),
       CharacterCount.configure({

--- a/src/components/editor/Tiptap.tsx
+++ b/src/components/editor/Tiptap.tsx
@@ -48,7 +48,7 @@ const Tiptap = ({ onChange, content }: TiptapProps) => {
         paragraph: {
           HTMLAttributes:
           {
-            class: 'mb-6',
+            class: 'mb-6 break-all',
           }
         },
         bulletList: ({
@@ -89,7 +89,6 @@ const Tiptap = ({ onChange, content }: TiptapProps) => {
         validate: (href: string) => /^https?:\/\//.test(href),
         HTMLAttributes: {
           class: 'text-primary',
-          target: '_blank',
         },
       }),
       CharacterCount.configure({
@@ -120,7 +119,7 @@ const Tiptap = ({ onChange, content }: TiptapProps) => {
   });
 
   return (
-    <div className='relative min-h-[500px] w-full border-muted shadow-lg'>
+    <div className='relative min-h-[500px] w-full max-w-[992px] border-muted shadow-lg'>
       <Toolbar editor={editor} content={content}/>
       <EditorContent style={{ whiteSpace: 'pre-line' }} editor={editor} />
     </div>

--- a/src/components/editor/Toolbar.tsx
+++ b/src/components/editor/Toolbar.tsx
@@ -69,7 +69,7 @@ const Toolbar = ({ editor }: Props) => {
         src: url,
         alt: '',
         title: '',
-        className: 'rounded-lg border border-muted',
+        className: 'rounded-lg border border-muted w-full',
         'data-keep-ratio': true,
       });
       editor.chain().focus();

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -41,3 +41,8 @@ export const EXPLORE_LIST: Omit<Category, 'articleCount'>[] = [
 ];
 
 export const NEWEB_PAY_DATA_NAMES = ['Version', 'MerchantID', 'TradeInfo', 'TradeSha'] as const;
+
+export const IS_NEED_PAY_OPTIONS = [
+  { id: '免費', name: '免費' },
+  { id: '付費', name: '付費' }
+];

--- a/src/hook/usePublishForm.tsx
+++ b/src/hook/usePublishForm.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { Tag } from 'emblor';
+import { getCategories } from '@/lib/nextApi';
+import { useRouter } from 'next/navigation';
+import { toast } from '@/components/ui/use-toast';
+import { handleApiError } from '@/lib/utils';
+import { useEditor } from '@/stores/useEditorStore';
+import { createArticle, editArticle } from '@/lib/authApi';
+import { zodResolver } from '@hookform/resolvers/zod';
+import StatusCode from '@/types/StatusCode';
+import { IS_NEED_PAY_OPTIONS } from '@/constants';
+
+interface InitialValues {
+  title: string;
+  abstract: string;
+  thumbnailUrl: string;
+  category: string;
+  isNeedPay: boolean | string;
+  tags?: Tag[];
+}
+
+function convertTags(tagTexts: string[]): Tag[] {
+  return tagTexts.map((text, index) => ({
+    id: (index + 1).toString(),
+    text: text
+  }));
+}
+
+export function usePublishForm(initialValues: InitialValues, isEdit: boolean, articleId?: string) {
+  const { editorProps } = useEditor();
+  const router = useRouter();
+  const defaultTags: string[] = editorProps?.tags || [];
+  const [tags, setTags] = useState <Tag[]> (convertTags(defaultTags) || []);
+  const [categoryOptions, setCategoryOptions] = useState<{ id: string; name: string; }[]>([]);
+  const { mutate: mutateArticle, isPending: isUpdateArticle } = useMutation({
+    mutationFn: isEdit ? editArticle : createArticle
+  });
+
+  const categoryValidation = z.string().refine(value => categoryOptions.some(option => option.name === value), {
+    message: '選項為必填',
+  });
+
+  const isNeedPayValidation = z.string().refine(value => IS_NEED_PAY_OPTIONS.some(option => option.name === value), {
+    message: '選項為必填',
+  });
+
+  const formSchema = z.object({
+    title: z.string().min(1, { message: '標題是必填欄位' }).max(30, { message: '標題不能超過60個字' }),
+    abstract: z.string().max(150, { message: '摘要不能超過150個字' }),
+    thumbnailUrl: z.string().optional().refine(val => !val || val.startsWith('https://'), { message: '請輸入有效的網址，並以 https:// 開頭' }),
+    category: categoryValidation,
+    isNeedPay: isNeedPayValidation,
+    tags: z.array(z.object({ id: z.string(), text: z.string() })).optional(),
+  });
+
+  type FormData = z.infer<typeof formSchema>;
+
+  const form = useForm<FormData>({
+    mode: 'onBlur',
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      ...initialValues,
+      isNeedPay: initialValues.isNeedPay ? '付費' : '免費',
+      tags: []
+    },
+  });
+
+  useEffect(() => {
+    async function fetchCategories() {
+      try {
+        const res = await getCategories();
+        const categoryOptions = res.map(({ id, name }) => ({ id, name }));
+        setCategoryOptions(categoryOptions);
+      } catch (error) {
+        toast({ title: 'Error fetching categories: ' + error + '', variant: 'error' });
+      }
+    }
+
+    fetchCategories();
+  }, []);
+
+  function onSubmit(values: z.infer<typeof formSchema>) {
+    if (!editorProps) return;
+
+    const tags = values.tags?.map(tag => tag.text) || [];
+    const isNeedPay = (values.isNeedPay === '免費') ? false : true;
+    const { title, abstract, category } = values;
+    const articleBody = {
+      ...editorProps,
+      isNeedPay,
+      title,
+      abstract,
+      category,
+      tags
+    };
+    if (values.thumbnailUrl) {
+      articleBody.thumbnailUrl = values.thumbnailUrl;
+    }
+
+    mutateArticle(articleBody, {
+      onSuccess: () => {
+        const successTitle = isEdit ? '文章編輯成功' : '文章發布成功';
+        const successDescription = isEdit ? '即將為您跳轉至文章頁' : '即將為您跳轉至文章管理頁';
+        toast({ title: successTitle, description: successDescription, variant: 'success' });
+
+        isEdit ? window.location.href = `/article/${articleId}` : router.push('/manage/content');
+      },
+      onError: (error) => {
+        handleApiError(error, {
+          [StatusCode.ILLEGAL_PAYLOAD]: () => {
+            toast({ title: '請檢查輸入資料', variant: 'error' });
+          },
+          [StatusCode.PERMISSION_DENIED]: () => {
+            toast({ title: '請重新登入', variant: 'error' });
+          },
+        }, isEdit ? '編輯文章' : '發布文章');
+      },
+    });
+  }
+
+  return { form, onSubmit, categoryOptions, tags, setTags, isUpdateArticle };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,7 +6,6 @@ import { isAxiosError } from 'axios';
 import { toast } from '@/components/ui/use-toast';
 import StatusCode from '@/types/StatusCode';
 import { ApiResponse } from '@/types/apiResponse';
-import { useRouter } from 'next/navigation';
 import { OrderBy } from '@/types/enum';
 import { LOCAL_STORAGE_KEY, NEWEB_PAY_DATA_NAMES } from '@/constants';
 import { NewebpayRequestData } from '@/types';
@@ -34,19 +33,6 @@ export function handleApiError(error: unknown, config: ErrorHandlingConfig, oper
   }
 }
 
-export function verifyAuthor (
-  creatorId: string,
-  currentUserId: string,
-  router: ReturnType<typeof useRouter>,
-  onSuccess: () => void
-) {
-  if (creatorId === currentUserId) {
-    onSuccess();
-  } else {
-    toast({ title: '您沒有編輯此文章的權限', variant: 'error' });
-    // router.replace('/');
-  }
-};
 export const storeRedirectPath = (pathname: string) => {
   localStorage.setItem(LOCAL_STORAGE_KEY.redirectUrl, pathname);
 };


### PR DESCRIPTION
重構與修復項目

- 編輯、發佈頁重構錯誤流程處理
- fix tags bug (可能是 issue 7 的問題)

編輯器

 -  連結在文章上可另開頁面
 -  加上最大寬度防止輸入框外溢

文章頁

 -  文章圖片在手機版上自適應寬度
 -  p 標籤文字換行

增加項目

-   登入登出加入 `router.refresh`，送出文章使用 `window.location.href`
-   input select 控件加上 * 參數 isRequired = true